### PR TITLE
New features: ModBus that works with software serial! and fixed some problems.

### DIFF
--- a/ModbusRtu.h
+++ b/ModbusRtu.h
@@ -4,13 +4,13 @@
  * @date        2016.02.21
  * @author 	Samuel Marco i Armengol
  * @contact     sammarcoarmengol@gmail.com
- * @contribution 
+ * @contribution Helium6072
  *
  * @description
- *  Arduino library for communicating with Modbus devices 
+ *  Arduino library for communicating with Modbus devices
  *  over RS232/USB/485 via RTU protocol.
  *
- *  Further information: 
+ *  Further information:
  *  http://modbus.org/
  *  http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf
  *
@@ -19,16 +19,16 @@
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; version
  *  2.1 of the License.
- * 
+ *
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this library; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  * @defgroup setup Modbus Object Instantiation/Initialization
  * @defgroup loop Modbus Object Management
  * @defgroup buffer Modbus Buffer Management
@@ -38,30 +38,33 @@
  */
 
 #include <inttypes.h>
-#include "Arduino.h"	
+#include "Arduino.h"
 #include "Print.h"
+#include <SoftwareSerial.h>
 
 /**
- * @struct modbus_t 
- * @brief 
+ * @struct modbus_t
+ * @brief
  * Master query structure:
  * This includes all the necessary fields to make the Master generate a Modbus query.
  * A Master may keep several of these structures and send them cyclically or
  * use them according to program needs.
  */
-typedef struct {
-  uint8_t u8id;          /*!< Slave address between 1 and 247. 0 means broadcast */
-  uint8_t u8fct;         /*!< Function code: 1, 2, 3, 4, 5, 6, 15 or 16 */
-  uint16_t u16RegAdd;    /*!< Address of the first register to access at slave/s */
-  uint16_t u16CoilsNo;   /*!< Number of coils or registers to access */
-  uint16_t *au16reg;     /*!< Pointer to memory image in master */
-} 
+typedef struct
+{
+    uint8_t u8id;          /*!< Slave address between 1 and 247. 0 means broadcast */
+    uint8_t u8fct;         /*!< Function code: 1, 2, 3, 4, 5, 6, 15 or 16 */
+    uint16_t u16RegAdd;    /*!< Address of the first register to access at slave/s */
+    uint16_t u16CoilsNo;   /*!< Number of coils or registers to access */
+    uint16_t *au16reg;     /*!< Pointer to memory image in master */
+}
 modbus_t;
 
-enum { 
-  RESPONSE_SIZE = 6, 
-  EXCEPTION_SIZE = 3, 
-  CHECKSUM_SIZE = 2
+enum
+{
+    RESPONSE_SIZE = 6,
+    EXCEPTION_SIZE = 3,
+    CHECKSUM_SIZE = 2
 };
 
 /**
@@ -69,133 +72,144 @@ enum {
  * @brief
  * Indexes to telegram frame positions
  */
-enum MESSAGE {
-  ID                             = 0, //!< ID field
-  FUNC, //!< Function code position
-  ADD_HI, //!< Address high byte
-  ADD_LO, //!< Address low byte
-  NB_HI, //!< Number of coils or registers high byte
-  NB_LO, //!< Number of coils or registers low byte
-  BYTE_CNT  //!< byte counter
+enum MESSAGE
+{
+    ID                             = 0, //!< ID field
+    FUNC, //!< Function code position
+    ADD_HI, //!< Address high byte
+    ADD_LO, //!< Address low byte
+    NB_HI, //!< Number of coils or registers high byte
+    NB_LO, //!< Number of coils or registers low byte
+    BYTE_CNT  //!< byte counter
 };
 
 /**
  * @enum MB_FC
  * @brief
- * Modbus function codes summary. 
+ * Modbus function codes summary.
  * These are the implement function codes either for Master or for Slave.
  *
  * @see also fctsupported
  * @see also modbus_t
  */
-enum MB_FC {
-  MB_FC_NONE                     = 0,   /*!< null operator */
-  MB_FC_READ_COILS               = 1,	/*!< FCT=1 -> read coils or digital outputs */
-  MB_FC_READ_DISCRETE_INPUT      = 2,	/*!< FCT=2 -> read digital inputs */
-  MB_FC_READ_REGISTERS           = 3,	/*!< FCT=3 -> read registers or analog outputs */
-  MB_FC_READ_INPUT_REGISTER      = 4,	/*!< FCT=4 -> read analog inputs */
-  MB_FC_WRITE_COIL               = 5,	/*!< FCT=5 -> write single coil or output */
-  MB_FC_WRITE_REGISTER           = 6,	/*!< FCT=6 -> write single register */
-  MB_FC_WRITE_MULTIPLE_COILS     = 15,	/*!< FCT=15 -> write multiple coils or outputs */
-  MB_FC_WRITE_MULTIPLE_REGISTERS = 16	/*!< FCT=16 -> write multiple registers */
+enum MB_FC
+{
+    MB_FC_NONE                     = 0,   /*!< null operator */
+    MB_FC_READ_COILS               = 1,	/*!< FCT=1 -> read coils or digital outputs */
+    MB_FC_READ_DISCRETE_INPUT      = 2,	/*!< FCT=2 -> read digital inputs */
+    MB_FC_READ_REGISTERS           = 3,	/*!< FCT=3 -> read registers or analog outputs */
+    MB_FC_READ_INPUT_REGISTER      = 4,	/*!< FCT=4 -> read analog inputs */
+    MB_FC_WRITE_COIL               = 5,	/*!< FCT=5 -> write single coil or output */
+    MB_FC_WRITE_REGISTER           = 6,	/*!< FCT=6 -> write single register */
+    MB_FC_WRITE_MULTIPLE_COILS     = 15,	/*!< FCT=15 -> write multiple coils or outputs */
+    MB_FC_WRITE_MULTIPLE_REGISTERS = 16	/*!< FCT=16 -> write multiple registers */
 };
 
-enum COM_STATES {
-  COM_IDLE                     = 0,
-  COM_WAITING                  = 1
+enum COM_STATES
+{
+    COM_IDLE                     = 0,
+    COM_WAITING                  = 1
 
 };
 
-enum ERR_LIST {
-  ERR_NOT_MASTER                = -1,
-  ERR_POLLING                   = -2,
-  ERR_BUFF_OVERFLOW             = -3,
-  ERR_BAD_CRC                   = -4,
-  ERR_EXCEPTION                 = -5
+enum ERR_LIST
+{
+    ERR_NOT_MASTER                = -1,
+    ERR_POLLING                   = -2,
+    ERR_BUFF_OVERFLOW             = -3,
+    ERR_BAD_CRC                   = -4,
+    ERR_EXCEPTION                 = -5
 };
 
-enum { 
-  NO_REPLY = 255, 		
-  EXC_FUNC_CODE = 1,
-  EXC_ADDR_RANGE = 2, 		
-  EXC_REGS_QUANT = 3,  
-  EXC_EXECUTE = 4 
+enum
+{
+    NO_REPLY = 255,
+    EXC_FUNC_CODE = 1,
+    EXC_ADDR_RANGE = 2,
+    EXC_REGS_QUANT = 3,
+    EXC_EXECUTE = 4
 };
 
-const unsigned char fctsupported[] = { 
-  MB_FC_READ_COILS,
-  MB_FC_READ_DISCRETE_INPUT,
-  MB_FC_READ_REGISTERS, 
-  MB_FC_READ_INPUT_REGISTER,
-  MB_FC_WRITE_COIL,
-  MB_FC_WRITE_REGISTER, 
-  MB_FC_WRITE_MULTIPLE_COILS,
-  MB_FC_WRITE_MULTIPLE_REGISTERS
+const unsigned char fctsupported[] =
+{
+    MB_FC_READ_COILS,
+    MB_FC_READ_DISCRETE_INPUT,
+    MB_FC_READ_REGISTERS,
+    MB_FC_READ_INPUT_REGISTER,
+    MB_FC_WRITE_COIL,
+    MB_FC_WRITE_REGISTER,
+    MB_FC_WRITE_MULTIPLE_COILS,
+    MB_FC_WRITE_MULTIPLE_REGISTERS
 };
 
 #define T35  5
 #define  MAX_BUFFER  64	//!< maximum size for the communication buffer in bytes
 
 /**
- * @class Modbus 
+ * @class Modbus
  * @brief
  * Arduino class library for communicating with Modbus devices over
  * USB/RS232/485 (via RTU protocol).
  */
-class Modbus {
+class Modbus
+{
 private:
-  HardwareSerial *port; //!< Pointer to Serial class object
-  uint8_t u8id; //!< 0=master, 1..247=slave number
-  uint8_t u8serno; //!< serial port: 0-Serial, 1..3-Serial1..Serial3
-  uint8_t u8txenpin; //!< flow control pin: 0=USB or RS-232 mode, >0=RS-485 mode
-  uint8_t u8state;
-  uint8_t u8lastError;
-  uint8_t au8Buffer[MAX_BUFFER];
-  uint8_t u8BufferSize;
-  uint8_t u8lastRec;
-  uint16_t *au16regs;
-  uint16_t u16InCnt, u16OutCnt, u16errCnt;
-  uint16_t u16timeOut;
-  uint32_t u32time, u32timeOut;
-  uint8_t u8regsize;
+    HardwareSerial *port; //!< Pointer to Serial class object
+    SoftwareSerial *softPort; //!< Pointer to SoftwareSerial class object
+    uint8_t u8id; //!< 0=master, 1..247=slave number
+    uint8_t u8serno; //!< serial port: 0-Serial, 1..3-Serial1..Serial3; 4: use software serial
+    uint8_t u8txenpin; //!< flow control pin: 0=USB or RS-232 mode, >0=RS-485 mode
+    uint8_t u8state;
+    uint8_t u8lastError;
+    uint8_t au8Buffer[MAX_BUFFER];
+    uint8_t u8BufferSize;
+    uint8_t u8lastRec;
+    uint16_t *au16regs;
+    uint16_t u16InCnt, u16OutCnt, u16errCnt;
+    uint16_t u16timeOut;
+    uint32_t u32time, u32timeOut;
+    uint8_t u8regsize;
 
-  void init(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin);
-  void sendTxBuffer(); 
-  int8_t getRxBuffer(); 
-  uint16_t calcCRC(uint8_t u8length);
-  uint8_t validateAnswer();
-  uint8_t validateRequest(); 
-  void get_FC1(); 
-  void get_FC3(); 
-  int8_t process_FC1( uint16_t *regs, uint8_t u8size ); 
-  int8_t process_FC3( uint16_t *regs, uint8_t u8size ); 
-  int8_t process_FC5( uint16_t *regs, uint8_t u8size ); 
-  int8_t process_FC6( uint16_t *regs, uint8_t u8size ); 
-  int8_t process_FC15( uint16_t *regs, uint8_t u8size ); 
-  int8_t process_FC16( uint16_t *regs, uint8_t u8size ); 
-  void buildException( uint8_t u8exception ); // build exception message
+    void init(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin);
+	void init(uint8_t u8id);
+    void sendTxBuffer();
+    int8_t getRxBuffer();
+    uint16_t calcCRC(uint8_t u8length);
+    uint8_t validateAnswer();
+    uint8_t validateRequest();
+    void get_FC1();
+    void get_FC3();
+    int8_t process_FC1( uint16_t *regs, uint8_t u8size );
+    int8_t process_FC3( uint16_t *regs, uint8_t u8size );
+    int8_t process_FC5( uint16_t *regs, uint8_t u8size );
+    int8_t process_FC6( uint16_t *regs, uint8_t u8size );
+    int8_t process_FC15( uint16_t *regs, uint8_t u8size );
+    int8_t process_FC16( uint16_t *regs, uint8_t u8size );
+    void buildException( uint8_t u8exception ); // build exception message
 
 public:
-  Modbus(); 
-  Modbus(uint8_t u8id, uint8_t u8serno); 
-  Modbus(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin);
-  void begin(long u32speed);
-  void begin(long u32speed, uint8_t u8config);
-  void begin();
-  void setTimeOut( uint16_t u16timeout); //!<write communication watch-dog timer
-  uint16_t getTimeOut(); //!<get communication watch-dog timer value
-  boolean getTimeOutState(); //!<get communication watch-dog timer state
-  int8_t query( modbus_t telegram ); //!<only for master
-  int8_t poll(); //!<cyclic poll for master
-  int8_t poll( uint16_t *regs, uint8_t u8size ); //!<cyclic poll for slave
-  uint16_t getInCnt(); //!<number of incoming messages
-  uint16_t getOutCnt(); //!<number of outcoming messages
-  uint16_t getErrCnt(); //!<error counter
-  uint8_t getID(); //!<get slave ID between 1 and 247
-  uint8_t getState();
-  uint8_t getLastError(); //!<get last error message
-  void setID( uint8_t u8id ); //!<write new ID for the slave
-  void end(); //!<finish any communication and release serial communication port
+    Modbus();
+    Modbus(uint8_t u8id, uint8_t u8serno);
+    Modbus(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin);
+    Modbus(uint8_t u8id);
+    void begin(long u32speed);
+    void begin(SoftwareSerial *sPort, long u32speed);
+    void begin(long u32speed, uint8_t u8config);
+    void begin();
+    void setTimeOut( uint16_t u16timeout); //!<write communication watch-dog timer
+    uint16_t getTimeOut(); //!<get communication watch-dog timer value
+    boolean getTimeOutState(); //!<get communication watch-dog timer state
+    int8_t query( modbus_t telegram ); //!<only for master
+    int8_t poll(); //!<cyclic poll for master
+    int8_t poll( uint16_t *regs, uint8_t u8size ); //!<cyclic poll for slave
+    uint16_t getInCnt(); //!<number of incoming messages
+    uint16_t getOutCnt(); //!<number of outcoming messages
+    uint16_t getErrCnt(); //!<error counter
+    uint8_t getID(); //!<get slave ID between 1 and 247
+    uint8_t getState();
+    uint8_t getLastError(); //!<get last error message
+    void setID( uint8_t u8id ); //!<write new ID for the slave
+    void end(); //!<finish any communication and release serial communication port
 };
 
 /* _____PUBLIC FUNCTIONS_____________________________________________________ */
@@ -203,154 +217,215 @@ public:
 /**
  * @brief
  * Default Constructor for Master through Serial
- * 
+ *
  * @ingroup setup
  */
-Modbus::Modbus() {
-  init(0, 0, 0);
+Modbus::Modbus()
+{
+    init(0, 0, 0);
 }
 
 /**
  * @brief
  * Full constructor for a Master/Slave through USB/RS232C
- * 
+ *
  * @param u8id   node address 0=master, 1..247=slave
  * @param u8serno  serial port used 0..3
  * @ingroup setup
  * @overload Modbus::Modbus(uint8_t u8id, uint8_t u8serno)
+ * @overload Modbus::Modbus(uint8_t u8id)
  * @overload Modbus::Modbus()
  */
-Modbus::Modbus(uint8_t u8id, uint8_t u8serno) {
-  init(u8id, u8serno, 0);
+Modbus::Modbus(uint8_t u8id, uint8_t u8serno)
+{
+    init(u8id, u8serno, 0);
 }
 
 /**
  * @brief
  * Full constructor for a Master/Slave through USB/RS232C/RS485
  * It needs a pin for flow control only for RS485 mode
- * 
+ *
  * @param u8id   node address 0=master, 1..247=slave
  * @param u8serno  serial port used 0..3
  * @param u8txenpin pin for txen RS-485 (=0 means USB/RS232C mode)
  * @ingroup setup
  * @overload Modbus::Modbus(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin)
+ * @overload Modbus::Modbus(uint8_t u8id)
  * @overload Modbus::Modbus()
  */
-Modbus::Modbus(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin) {
-  init(u8id, u8serno, u8txenpin);
+Modbus::Modbus(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin)
+{
+    init(u8id, u8serno, u8txenpin);
+}
+
+/**
+ * @brief
+ * Constructor for a Master/Slave through USB/RS232C via software serial
+ * This constructor only specifies u8id (node address) and should be only
+ * used if you want to use software serial instead of hardware serial.
+ * If you use this constructor you have to begin ModBus object by
+ * using "void Modbus::begin(SoftwareSerial *softPort, long u32speed)".
+ *
+ * @param u8id   node address 0=master, 1..247=slave
+ * @ingroup setup
+ * @overload Modbus::Modbus(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin)
+ * @overload Modbus::Modbus(uint8_t u8id, uint8_t u8serno)
+ * @overload Modbus::Modbus()
+ */
+Modbus::Modbus(uint8_t u8id)
+{
+    init(u8id);
 }
 
 /**
  * @brief
  * Initialize class object.
- * 
+ *
  * Sets up the serial port using specified baud rate.
  * Call once class has been instantiated, typically within setup().
- * 
+ *
  * @see http://arduino.cc/en/Serial/Begin#.Uy4CJ6aKlHY
  * @param speed   baud rate, in standard increments (300..115200)
  * @ingroup setup
  */
-void Modbus::begin(long u32speed) {
+void Modbus::begin(long u32speed)
+{
 
-  switch( u8serno ) {
+    switch( u8serno )
+    {
 #if defined(UBRR1H)
-  case 1:
-    port = &Serial1;
-    break;
+    case 1:
+        port = &Serial1;
+        break;
 #endif
 
 #if defined(UBRR2H)
-  case 2:
-    port = &Serial2;
-    break;
+    case 2:
+        port = &Serial2;
+        break;
 #endif
 
 #if defined(UBRR3H)
-  case 3:
-    port = &Serial3;
-    break;
+    case 3:
+        port = &Serial3;
+        break;
 #endif
-  case 0:
-  default:
-    port = &Serial;
-    break;
-  }
+    case 0:
+    default:
+        port = &Serial;
+        break;
+    }
 
-  port->begin(u32speed);
-  if (u8txenpin > 1) { // pin 0 & pin 1 are reserved for RX/TX
-    // return RS485 transceiver to transmit mode
-    pinMode(u8txenpin, OUTPUT);
-    digitalWrite(u8txenpin, LOW);
-  }
+    port->begin(u32speed);
+    if (u8txenpin > 1)   // pin 0 & pin 1 are reserved for RX/TX
+    {
+        // return RS485 transceiver to transmit mode
+        pinMode(u8txenpin, OUTPUT);
+        digitalWrite(u8txenpin, LOW);
+    }
 
-  port->flush();
-  u8lastRec = u8BufferSize = 0;
-  u16InCnt = u16OutCnt = u16errCnt = 0;
+    while(port->read() >= 0);
+    u8lastRec = u8BufferSize = 0;
+    u16InCnt = u16OutCnt = u16errCnt = 0;
 }
 
 /**
  * @brief
  * Initialize class object.
- * 
+ *
+ * Sets up the software serial port using specified baud rate and SoftwareSerial object.
+ * Call once class has been instantiated, typically within setup().
+ *
+ * @param speed   *softPort, pointer to SoftwareSerial class object
+ * @param speed   baud rate, in standard increments (300..115200)
+ * @ingroup setup
+ */
+void Modbus::begin(SoftwareSerial *sPort, long u32speed)
+{
+
+    softPort=sPort;
+
+    softPort->begin(u32speed);
+
+    if (u8txenpin > 1)   // pin 0 & pin 1 are reserved for RX/TX
+    {
+        // return RS485 transceiver to transmit mode
+        pinMode(u8txenpin, OUTPUT);
+        digitalWrite(u8txenpin, LOW);
+    }
+
+    while(softPort->read() >= 0);
+    u8lastRec = u8BufferSize = 0;
+    u16InCnt = u16OutCnt = u16errCnt = 0;
+}
+
+/**
+ * @brief
+ * Initialize class object.
+ *
  * Sets up the serial port using specified baud rate.
  * Call once class has been instantiated, typically within setup().
- * 
+ *
  * @see http://arduino.cc/en/Serial/Begin#.Uy4CJ6aKlHY
  * @param speed   baud rate, in standard increments (300..115200)
  * @param config  data frame settings (data length, parity and stop bits)
  * @ingroup setup
  */
-void Modbus::begin(long u32speed,uint8_t u8config) {
+void Modbus::begin(long u32speed,uint8_t u8config)
+{
 
-  switch( u8serno ) {
+    switch( u8serno )
+    {
 #if defined(UBRR1H)
-  case 1:
-    port = &Serial1;
-    break;
+    case 1:
+        port = &Serial1;
+        break;
 #endif
 
 #if defined(UBRR2H)
-  case 2:
-    port = &Serial2;
-    break;
+    case 2:
+        port = &Serial2;
+        break;
 #endif
 
 #if defined(UBRR3H)
-  case 3:
-    port = &Serial3;
-    break;
+    case 3:
+        port = &Serial3;
+        break;
 #endif
-  case 0:
-  default:
-    port = &Serial;
-    break;
-  }
+    case 0:
+    default:
+        port = &Serial;
+        break;
+    }
 
-  port->begin(u32speed, u8config);
-  if (u8txenpin > 1) { // pin 0 & pin 1 are reserved for RX/TX
-    // return RS485 transceiver to transmit mode
-    pinMode(u8txenpin, OUTPUT);
-    digitalWrite(u8txenpin, LOW);
-  }
+    port->begin(u32speed, u8config);
+    if (u8txenpin > 1)   // pin 0 & pin 1 are reserved for RX/TX
+    {
+        // return RS485 transceiver to transmit mode
+        pinMode(u8txenpin, OUTPUT);
+        digitalWrite(u8txenpin, LOW);
+    }
 
-  port->flush();
-  u8lastRec = u8BufferSize = 0;
-  u16InCnt = u16OutCnt = u16errCnt = 0;
+    while(port->read() >= 0);
+    u8lastRec = u8BufferSize = 0;
+    u16InCnt = u16OutCnt = u16errCnt = 0;
 }
 
 /**
  * @brief
  * Initialize default class object.
- * 
+ *
  * Sets up the serial port using 19200 baud.
  * Call once class has been instantiated, typically within setup().
- * 
+ *
  * @overload Modbus::begin(uint16_t u16BaudRate)
  * @ingroup setup
  */
-void Modbus::begin() {
-  begin(19200);
+void Modbus::begin()
+{
+    begin(19200);
 }
 
 /**
@@ -360,10 +435,12 @@ void Modbus::begin() {
  * @param 	u8id	new slave address between 1 and 247
  * @ingroup setup
  */
-void Modbus::setID( uint8_t u8id) {
-  if (( u8id != 0) && (u8id <= 247)) {
-    this->u8id = u8id;
-  }
+void Modbus::setID( uint8_t u8id)
+{
+    if (( u8id != 0) && (u8id <= 247))
+    {
+        this->u8id = u8id;
+    }
 }
 
 /**
@@ -373,23 +450,25 @@ void Modbus::setID( uint8_t u8id) {
  * @return u8id	current slave address between 1 and 247
  * @ingroup setup
  */
-uint8_t Modbus::getID() {
-  return this->u8id;
+uint8_t Modbus::getID()
+{
+    return this->u8id;
 }
 
 /**
  * @brief
  * Initialize time-out parameter
- * 
+ *
  * Call once class has been instantiated, typically within setup().
  * The time-out timer is reset each time that there is a successful communication
  * between Master and Slave. It works for both.
- * 
+ *
  * @param time-out value (ms)
  * @ingroup setup
  */
-void Modbus::setTimeOut( uint16_t u16timeOut) {
-  this->u16timeOut = u16timeOut;
+void Modbus::setTimeOut( uint16_t u16timeOut)
+{
+    this->u16timeOut = u16timeOut;
 }
 
 /**
@@ -400,67 +479,73 @@ void Modbus::setTimeOut( uint16_t u16timeOut) {
  * @return TRUE if millis() > u32timeOut
  * @ingroup loop
  */
-boolean Modbus::getTimeOutState() {
-  return (millis() > u32timeOut);
+boolean Modbus::getTimeOutState()
+{
+    return (millis() > u32timeOut);
 }
 
 /**
  * @brief
  * Get input messages counter value
  * This can be useful to diagnose communication
- * 
+ *
  * @return input messages counter
  * @ingroup buffer
  */
-uint16_t Modbus::getInCnt() { 
-  return u16InCnt; 
+uint16_t Modbus::getInCnt()
+{
+    return u16InCnt;
 }
 
 /**
  * @brief
  * Get transmitted messages counter value
  * This can be useful to diagnose communication
- * 
+ *
  * @return transmitted messages counter
  * @ingroup buffer
  */
-uint16_t Modbus::getOutCnt() { 
-  return u16OutCnt; 
+uint16_t Modbus::getOutCnt()
+{
+    return u16OutCnt;
 }
 
 /**
  * @brief
  * Get errors counter value
  * This can be useful to diagnose communication
- * 
+ *
  * @return errors counter
  * @ingroup buffer
  */
-uint16_t Modbus::getErrCnt() { 
-  return u16errCnt; 
+uint16_t Modbus::getErrCnt()
+{
+    return u16errCnt;
 }
 
 /**
  * Get modbus master state
- * 
+ *
  * @return = 0 IDLE, = 1 WAITING FOR ANSWER
  * @ingroup buffer
  */
-uint8_t Modbus::getState() {
-  return u8state;
+uint8_t Modbus::getState()
+{
+    return u8state;
 }
 
 /**
  * Get the last error in the protocol processor
- * 
+ *
  * @returnreturn   NO_REPLY = 255      Time-out
  * @return   EXC_FUNC_CODE = 1   Function code not available
- * @return   EXC_ADDR_RANGE = 2  Address beyond available space for Modbus registers 
+ * @return   EXC_ADDR_RANGE = 2  Address beyond available space for Modbus registers
  * @return   EXC_REGS_QUANT = 3  Coils or registers number beyond the available space
  * @ingroup buffer
  */
-uint8_t Modbus::getLastError() {
-  return u8lastError;
+uint8_t Modbus::getLastError()
+{
+    return u8lastError;
 }
 
 /**
@@ -469,84 +554,89 @@ uint8_t Modbus::getLastError() {
  * Generate a query to an slave with a modbus_t telegram structure
  * The Master must be in COM_IDLE mode. After it, its state would be COM_WAITING.
  * This method has to be called only in loop() section.
- * 
- * @see modbus_t 
+ *
+ * @see modbus_t
  * @param modbus_t  modbus telegram structure (id, fct, ...)
  * @ingroup loop
  * @todo finish function 15
  */
-int8_t Modbus::query( modbus_t telegram ) {
-  uint8_t u8regsno, u8bytesno;
-  if (u8id!=0) return -2;
-  if (u8state != COM_IDLE) return -1;
+int8_t Modbus::query( modbus_t telegram )
+{
+    uint8_t u8regsno, u8bytesno;
+    if (u8id!=0) return -2;
+    if (u8state != COM_IDLE) return -1;
 
-  if ((telegram.u8id==0) || (telegram.u8id>247)) return -3;
+    if ((telegram.u8id==0) || (telegram.u8id>247)) return -3;
 
-  au16regs = telegram.au16reg;
+    au16regs = telegram.au16reg;
 
-  // telegram header
-  au8Buffer[ ID ]         = telegram.u8id;
-  au8Buffer[ FUNC ]       = telegram.u8fct;
-  au8Buffer[ ADD_HI ]     = highByte(telegram.u16RegAdd );
-  au8Buffer[ ADD_LO ]     = lowByte( telegram.u16RegAdd );
+    // telegram header
+    au8Buffer[ ID ]         = telegram.u8id;
+    au8Buffer[ FUNC ]       = telegram.u8fct;
+    au8Buffer[ ADD_HI ]     = highByte(telegram.u16RegAdd );
+    au8Buffer[ ADD_LO ]     = lowByte( telegram.u16RegAdd );
 
-  switch( telegram.u8fct ) {
-  case MB_FC_READ_COILS:
-  case MB_FC_READ_DISCRETE_INPUT:
-  case MB_FC_READ_REGISTERS:
-  case MB_FC_READ_INPUT_REGISTER:
-    au8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
-    au8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );
-    u8BufferSize = 6;
-    break;
-  case MB_FC_WRITE_COIL:
-    au8Buffer[ NB_HI ]      = ((au16regs[0] > 0) ? 0xff : 0);
-    au8Buffer[ NB_LO ]      = 0;
-    u8BufferSize = 6;    
-    break;
-  case MB_FC_WRITE_REGISTER:
-    au8Buffer[ NB_HI ]      = highByte(au16regs[0]);
-    au8Buffer[ NB_LO ]      = lowByte(au16regs[0]);
-    u8BufferSize = 6;    
-    break;
-  case MB_FC_WRITE_MULTIPLE_COILS: // TODO: implement "sending coils"
-    u8regsno = telegram.u16CoilsNo / 16;
-    u8bytesno = u8regsno * 2;
-    if ((telegram.u16CoilsNo % 16) != 0) {
-      u8bytesno++;
-      u8regsno++;
+    switch( telegram.u8fct )
+    {
+    case MB_FC_READ_COILS:
+    case MB_FC_READ_DISCRETE_INPUT:
+    case MB_FC_READ_REGISTERS:
+    case MB_FC_READ_INPUT_REGISTER:
+        au8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
+        au8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );
+        u8BufferSize = 6;
+        break;
+    case MB_FC_WRITE_COIL:
+        au8Buffer[ NB_HI ]      = ((au16regs[0] > 0) ? 0xff : 0);
+        au8Buffer[ NB_LO ]      = 0;
+        u8BufferSize = 6;
+        break;
+    case MB_FC_WRITE_REGISTER:
+        au8Buffer[ NB_HI ]      = highByte(au16regs[0]);
+        au8Buffer[ NB_LO ]      = lowByte(au16regs[0]);
+        u8BufferSize = 6;
+        break;
+    case MB_FC_WRITE_MULTIPLE_COILS: // TODO: implement "sending coils"
+        u8regsno = telegram.u16CoilsNo / 16;
+        u8bytesno = u8regsno * 2;
+        if ((telegram.u16CoilsNo % 16) != 0)
+        {
+            u8bytesno++;
+            u8regsno++;
+        }
+
+        au8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
+        au8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );
+        au8Buffer[ NB_LO+1 ]    = u8bytesno;
+        u8BufferSize = 7;
+
+        u8regsno = u8bytesno = 0; // now auxiliary registers
+        for (uint16_t i = 0; i < telegram.u16CoilsNo; i++)
+        {
+
+
+        }
+        break;
+
+    case MB_FC_WRITE_MULTIPLE_REGISTERS:
+        au8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
+        au8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );
+        au8Buffer[ NB_LO+1 ]    = (uint8_t) ( telegram.u16CoilsNo * 2 );
+        u8BufferSize = 7;
+
+        for (uint16_t i=0; i< telegram.u16CoilsNo; i++)
+        {
+            au8Buffer[ u8BufferSize ] = highByte( au16regs[ i ] );
+            u8BufferSize++;
+            au8Buffer[ u8BufferSize ] = lowByte( au16regs[ i ] );
+            u8BufferSize++;
+        }
+        break;
     }
 
-    au8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
-    au8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );
-    au8Buffer[ NB_LO+1 ]    = u8bytesno;
-    u8BufferSize = 7;
-
-    u8regsno = u8bytesno = 0; // now auxiliary registers
-    for (uint16_t i = 0; i < telegram.u16CoilsNo; i++) {
-
-
-    }
-    break;
-
-  case MB_FC_WRITE_MULTIPLE_REGISTERS:
-    au8Buffer[ NB_HI ]      = highByte(telegram.u16CoilsNo );
-    au8Buffer[ NB_LO ]      = lowByte( telegram.u16CoilsNo );
-    au8Buffer[ NB_LO+1 ]    = (uint8_t) ( telegram.u16CoilsNo * 2 );
-    u8BufferSize = 7;    
-
-    for (uint16_t i=0; i< telegram.u16CoilsNo; i++) {
-      au8Buffer[ u8BufferSize ] = highByte( au16regs[ i ] );
-      u8BufferSize++;
-      au8Buffer[ u8BufferSize ] = lowByte( au16regs[ i ] );
-      u8BufferSize++;
-    }
-    break;
-  }
-
-  sendTxBuffer();
-  u8state = COM_WAITING;
-  return 0;
+    sendTxBuffer();
+    u8state = COM_WAITING;
+    return 0;
 }
 
 /**
@@ -558,71 +648,81 @@ int8_t Modbus::query( modbus_t telegram ) {
  *
  * Any incoming data would be redirected to au16regs pointer,
  * as defined in its modbus_t query telegram.
- * 
+ *
  * @params	nothing
  * @return errors counter
  * @ingroup loop
  */
-int8_t Modbus::poll() {
-  // check if there is any incoming frame
-  uint8_t u8current = port->available();  
+int8_t Modbus::poll()
+{
+    // check if there is any incoming frame
+	uint8_t u8current;
+    if(u8serno<4)
+        u8current = port->available();
+    else
+        u8current = softPort->available();
 
-  if (millis() > u32timeOut) {
+    if (millis() > u32timeOut)
+    {
+        u8state = COM_IDLE;
+        u8lastError = NO_REPLY;
+        u16errCnt++;
+        return 0;
+    }
+
+    if (u8current == 0) return 0;
+
+    // check T35 after frame end or still no frame end
+    if (u8current != u8lastRec)
+    {
+        u8lastRec = u8current;
+        u32time = millis() + T35;
+        return 0;
+    }
+    if (millis() < u32time) return 0;
+
+    // transfer Serial buffer frame to auBuffer
+    u8lastRec = 0;
+    int8_t i8state = getRxBuffer();
+    if (i8state < 7)
+    {
+        u8state = COM_IDLE;
+        u16errCnt++;
+        return i8state;
+    }
+
+    // validate message: id, CRC, FCT, exception
+    uint8_t u8exception = validateAnswer();
+    if (u8exception != 0)
+    {
+        u8state = COM_IDLE;
+        return u8exception;
+    }
+
+    // process answer
+    switch( au8Buffer[ FUNC ] )
+    {
+    case MB_FC_READ_COILS:
+    case MB_FC_READ_DISCRETE_INPUT:
+        // call get_FC1 to transfer the incoming message to au16regs buffer
+        get_FC1( );
+        break;
+    case MB_FC_READ_INPUT_REGISTER:
+    case MB_FC_READ_REGISTERS :
+        // call get_FC3 to transfer the incoming message to au16regs buffer
+        get_FC3( );
+        break;
+    case MB_FC_WRITE_COIL:
+    case MB_FC_WRITE_REGISTER :
+    case MB_FC_WRITE_MULTIPLE_COILS:
+    case MB_FC_WRITE_MULTIPLE_REGISTERS :
+        // nothing to do
+        break;
+    default:
+        break;
+    }
     u8state = COM_IDLE;
-    u8lastError = NO_REPLY;
-    u16errCnt++;
-    return 0;
-  }
-
-  if (u8current == 0) return 0;
-
-  // check T35 after frame end or still no frame end
-  if (u8current != u8lastRec) {
-    u8lastRec = u8current;
-    u32time = millis() + T35;
-    return 0;
-  }
-  if (millis() < u32time) return 0;
-
-  // transfer Serial buffer frame to auBuffer
-  u8lastRec = 0;
-  int8_t i8state = getRxBuffer();
-  if (i8state < 7) {
-    u8state = COM_IDLE;
-    u16errCnt++;
-    return i8state;
-  }
-
-  // validate message: id, CRC, FCT, exception
-  uint8_t u8exception = validateAnswer(); 
-  if (u8exception != 0) {
-    u8state = COM_IDLE;
-    return u8exception;
-  }
-
-  // process answer
-  switch( au8Buffer[ FUNC ] ) {
-  case MB_FC_READ_COILS:
-  case MB_FC_READ_DISCRETE_INPUT:
-    // call get_FC1 to transfer the incoming message to au16regs buffer
-    get_FC1( );
-    break;
-  case MB_FC_READ_INPUT_REGISTER:
-  case MB_FC_READ_REGISTERS :
-    // call get_FC3 to transfer the incoming message to au16regs buffer
-    get_FC3( );
-    break;
-  case MB_FC_WRITE_COIL:
-  case MB_FC_WRITE_REGISTER :
-  case MB_FC_WRITE_MULTIPLE_COILS:
-  case MB_FC_WRITE_MULTIPLE_REGISTERS :
-    // nothing to do
-    break;
-  default:
-    break;
-  }  
-  u8state = COM_IDLE;
-  return u8BufferSize;
+    return u8BufferSize;
 }
 
 /**
@@ -632,86 +732,106 @@ int8_t Modbus::poll() {
  * Afterwards, it would shoot a validation routine plus a register query
  * Avoid any delay() function !!!!
  * After a successful frame between the Master and the Slave, the time-out timer is reset.
- * 
+ *
  * @param *regs  register table for communication exchange
  * @param u8size  size of the register table
  * @return 0 if no query, 1..4 if communication error, >4 if correct query processed
  * @ingroup loop
  */
-int8_t Modbus::poll( uint16_t *regs, uint8_t u8size ) {
+int8_t Modbus::poll( uint16_t *regs, uint8_t u8size )
+{
 
-  au16regs = regs;
-  u8regsize = u8size;
+    au16regs = regs;
+    u8regsize = u8size;
+	uint8_t u8current;
 
-  // check if there is any incoming frame
-  uint8_t u8current = port->available();  
-  if (u8current == 0) return 0;
 
-  // check T35 after frame end or still no frame end
-  if (u8current != u8lastRec) {
-    u8lastRec = u8current;
-    u32time = millis() + T35;
-    return 0;
-  }
-  if (millis() < u32time) return 0;
+    // check if there is any incoming frame
+    if(u8serno<4)
+        u8current = port->available();
+    else
+        u8current = softPort->available();
 
-  u8lastRec = 0;
-  int8_t i8state = getRxBuffer();
-  u8lastError = i8state;
-  if (i8state < 7) return i8state;  
+    if (u8current == 0) return 0;
 
-  // check slave id
-  if (au8Buffer[ ID ] != u8id) return 0;
-
-  // validate message: CRC, FCT, address and size
-  uint8_t u8exception = validateRequest();
-  if (u8exception > 0) {
-    if (u8exception != NO_REPLY) {
-      buildException( u8exception );
-      sendTxBuffer(); 
+    // check T35 after frame end or still no frame end
+    if (u8current != u8lastRec)
+    {
+        u8lastRec = u8current;
+        u32time = millis() + T35;
+        return 0;
     }
-    u8lastError = u8exception;
-    return u8exception;
-  }
+    if (millis() < u32time) return 0;
 
-  u32timeOut = millis() + long(u16timeOut);
-  u8lastError = 0;
-  
-  // process message
-  switch( au8Buffer[ FUNC ] ) {
-  case MB_FC_READ_COILS:
-  case MB_FC_READ_DISCRETE_INPUT:
-    return process_FC1( regs, u8size );
-    break;
-  case MB_FC_READ_INPUT_REGISTER:
-  case MB_FC_READ_REGISTERS :
-    return process_FC3( regs, u8size );
-    break;
-  case MB_FC_WRITE_COIL:
-    return process_FC5( regs, u8size );
-    break;
-  case MB_FC_WRITE_REGISTER :
-    return process_FC6( regs, u8size );
-    break;
-  case MB_FC_WRITE_MULTIPLE_COILS:
-    return process_FC15( regs, u8size );
-    break;
-  case MB_FC_WRITE_MULTIPLE_REGISTERS :
-    return process_FC16( regs, u8size );
-    break;
-  default:
-    break;
-  }
-  return i8state;
+    u8lastRec = 0;
+    int8_t i8state = getRxBuffer();
+    u8lastError = i8state;
+    if (i8state < 7) return i8state;
+
+    // check slave id
+    if (au8Buffer[ ID ] != u8id) return 0;
+
+    // validate message: CRC, FCT, address and size
+    uint8_t u8exception = validateRequest();
+    if (u8exception > 0)
+    {
+        if (u8exception != NO_REPLY)
+        {
+            buildException( u8exception );
+            sendTxBuffer();
+        }
+        u8lastError = u8exception;
+        return u8exception;
+    }
+
+    u32timeOut = millis() + long(u16timeOut);
+    u8lastError = 0;
+
+    // process message
+    switch( au8Buffer[ FUNC ] )
+    {
+    case MB_FC_READ_COILS:
+    case MB_FC_READ_DISCRETE_INPUT:
+        return process_FC1( regs, u8size );
+        break;
+    case MB_FC_READ_INPUT_REGISTER:
+    case MB_FC_READ_REGISTERS :
+        return process_FC3( regs, u8size );
+        break;
+    case MB_FC_WRITE_COIL:
+        return process_FC5( regs, u8size );
+        break;
+    case MB_FC_WRITE_REGISTER :
+        return process_FC6( regs, u8size );
+        break;
+    case MB_FC_WRITE_MULTIPLE_COILS:
+        return process_FC15( regs, u8size );
+        break;
+    case MB_FC_WRITE_MULTIPLE_REGISTERS :
+        return process_FC16( regs, u8size );
+        break;
+    default:
+        break;
+    }
+    return i8state;
 }
 
 /* _____PRIVATE FUNCTIONS_____________________________________________________ */
 
-void Modbus::init(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin) {
-  this->u8id = u8id;
-  this->u8serno = (u8serno > 3) ? 0 : u8serno;
-  this->u8txenpin = u8txenpin;
-  this->u16timeOut = 1000;
+void Modbus::init(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin)
+{
+    this->u8id = u8id;
+    this->u8serno = (u8serno > 3) ? 0 : u8serno;
+    this->u8txenpin = u8txenpin;
+    this->u16timeOut = 1000;
+}
+
+void Modbus::init(uint8_t u8id)
+{
+    this->u8id = u8id;
+    this->u8serno = 4;
+    this->u8txenpin = 0;
+    this->u16timeOut = 1000;
 }
 
 /**
@@ -721,25 +841,37 @@ void Modbus::init(uint8_t u8id, uint8_t u8serno, uint8_t u8txenpin) {
  * @return buffer size if OK, ERR_BUFF_OVERFLOW if u8BufferSize >= MAX_BUFFER
  * @ingroup buffer
  */
-int8_t Modbus::getRxBuffer() {
-  boolean bBuffOverflow = false;
+int8_t Modbus::getRxBuffer()
+{
+    boolean bBuffOverflow = false;
 
-  if (u8txenpin > 1) digitalWrite( u8txenpin, LOW );
+    if (u8txenpin > 1) digitalWrite( u8txenpin, LOW );
 
-  u8BufferSize = 0;
-  while ( port->available() ) {
-    au8Buffer[ u8BufferSize ] = port->read();
-    u8BufferSize ++;
+    u8BufferSize = 0;
+    if(u8serno<4)
+        while ( port->available() )
+        {
+            au8Buffer[ u8BufferSize ] = port->read();
+            u8BufferSize ++;
 
-    if (u8BufferSize >= MAX_BUFFER) bBuffOverflow = true;
-  }
-  u16InCnt++;
+            if (u8BufferSize >= MAX_BUFFER) bBuffOverflow = true;
+        }
+    else
+        while ( softPort->available() )
+        {
+            au8Buffer[ u8BufferSize ] = softPort->read();
+            u8BufferSize ++;
 
-  if (bBuffOverflow) {
-    u16errCnt++;
-    return ERR_BUFF_OVERFLOW;
-  }
-  return u8BufferSize;
+            if (u8BufferSize >= MAX_BUFFER) bBuffOverflow = true;
+        }
+    u16InCnt++;
+
+    if (bBuffOverflow)
+    {
+        u16errCnt++;
+        return ERR_BUFF_OVERFLOW;
+    }
+    return u8BufferSize;
 }
 
 /**
@@ -754,84 +886,96 @@ int8_t Modbus::getRxBuffer() {
  * @return nothing
  * @ingroup buffer
  */
-void Modbus::sendTxBuffer() {
-  uint8_t i = 0;
+void Modbus::sendTxBuffer()
+{
+    uint8_t i = 0;
 
-  // append CRC to message
-  uint16_t u16crc = calcCRC( u8BufferSize );
-  au8Buffer[ u8BufferSize ] = u16crc >> 8;
-  u8BufferSize++;
-  au8Buffer[ u8BufferSize ] = u16crc & 0x00ff;
-  u8BufferSize++;
+    // append CRC to message
+    uint16_t u16crc = calcCRC( u8BufferSize );
+    au8Buffer[ u8BufferSize ] = u16crc >> 8;
+    u8BufferSize++;
+    au8Buffer[ u8BufferSize ] = u16crc & 0x00ff;
+    u8BufferSize++;
 
-  // set RS485 transceiver to transmit mode
-  if (u8txenpin > 1) {
-    switch( u8serno ) {
+    // set RS485 transceiver to transmit mode
+    if (u8txenpin > 1)
+    {
+        switch( u8serno )
+        {
 #if defined(UBRR1H)
-    case 1:
-      UCSR1A=UCSR1A |(1 << TXC1);
-      break;
+        case 1:
+            UCSR1A=UCSR1A |(1 << TXC1);
+            break;
 #endif
 
 #if defined(UBRR2H)
-    case 2:
-      UCSR2A=UCSR2A |(1 << TXC2);
-      break;
+        case 2:
+            UCSR2A=UCSR2A |(1 << TXC2);
+            break;
 #endif
 
 #if defined(UBRR3H)
-    case 3:
-      UCSR3A=UCSR3A |(1 << TXC3);
-      break;
+        case 3:
+            UCSR3A=UCSR3A |(1 << TXC3);
+            break;
 #endif
-    case 0:
-    default:
-      UCSR0A=UCSR0A |(1 << TXC0);
-      break;
+        case 0:
+        default:
+            UCSR0A=UCSR0A |(1 << TXC0);
+            break;
+        }
+        digitalWrite( u8txenpin, HIGH );
     }
-    digitalWrite( u8txenpin, HIGH );
-  }
 
-  // transfer buffer to serial line
-  port->write( au8Buffer, u8BufferSize );
+    // transfer buffer to serial line
+    if(u8serno<4)
+        port->write( au8Buffer, u8BufferSize );
+    else
+        softPort->write( au8Buffer, u8BufferSize );
 
-  // keep RS485 transceiver in transmit mode as long as sending
-  if (u8txenpin > 1) {
-    switch( u8serno ) {
+    // keep RS485 transceiver in transmit mode as long as sending
+    if (u8txenpin > 1)
+    {
+        switch( u8serno )
+        {
 #if defined(UBRR1H)
-    case 1:
-      while (!(UCSR1A & (1 << TXC1)));
-      break;
+        case 1:
+            while (!(UCSR1A & (1 << TXC1)));
+            break;
 #endif
 
 #if defined(UBRR2H)
-    case 2:
-      while (!(UCSR2A & (1 << TXC2)));
-      break;
+        case 2:
+            while (!(UCSR2A & (1 << TXC2)));
+            break;
 #endif
 
 #if defined(UBRR3H)
-    case 3:
-      while (!(UCSR3A & (1 << TXC3)));
-      break;
+        case 3:
+            while (!(UCSR3A & (1 << TXC3)));
+            break;
 #endif
-    case 0:
-    default:
-      while (!(UCSR0A & (1 << TXC0)));
-      break;
+        case 0:
+        default:
+            while (!(UCSR0A & (1 << TXC0)));
+            break;
+        }
+
+        // return RS485 transceiver to receive mode
+        digitalWrite( u8txenpin, LOW );
     }
+    if(u8serno<4)
+        while(port->read() >= 0);
+    else
+        while(softPort->read() >= 0);
 
-    // return RS485 transceiver to receive mode
-    digitalWrite( u8txenpin, LOW );
-  }
-  port->flush();
-  u8BufferSize = 0;
+    u8BufferSize = 0;
 
-  // set time-out for master
-  u32timeOut = millis() + (unsigned long) u16timeOut;
+    // set time-out for master
+    u32timeOut = millis() + (unsigned long) u16timeOut;
 
-  // increase message counter
-  u16OutCnt++;
+    // increase message counter
+    u16OutCnt++;
 }
 
 /**
@@ -841,25 +985,28 @@ void Modbus::sendTxBuffer() {
  * @return uint16_t calculated CRC value for the message
  * @ingroup buffer
  */
-uint16_t Modbus::calcCRC(uint8_t u8length) {
-  unsigned int temp, temp2, flag;
-  temp = 0xFFFF;
-  for (unsigned char i = 0; i < u8length; i++) {
-    temp = temp ^ au8Buffer[i];
-    for (unsigned char j = 1; j <= 8; j++) {
-      flag = temp & 0x0001;
-      temp >>=1;
-      if (flag)
-        temp ^= 0xA001;
+uint16_t Modbus::calcCRC(uint8_t u8length)
+{
+    unsigned int temp, temp2, flag;
+    temp = 0xFFFF;
+    for (unsigned char i = 0; i < u8length; i++)
+    {
+        temp = temp ^ au8Buffer[i];
+        for (unsigned char j = 1; j <= 8; j++)
+        {
+            flag = temp & 0x0001;
+            temp >>=1;
+            if (flag)
+                temp ^= 0xA001;
+        }
     }
-  }
-  // Reverse byte order. 
-  temp2 = temp >> 8;
-  temp = (temp << 8) | temp2;
-  temp &= 0xFFFF; 
-  // the returned value is already swapped
-  // crcLo byte is first & crcHi byte is last
-  return temp; 
+    // Reverse byte order.
+    temp2 = temp >> 8;
+    temp = (temp << 8) | temp2;
+    temp &= 0xFFFF;
+    // the returned value is already swapped
+    // crcLo byte is first & crcHi byte is last
+    return temp;
 }
 
 /**
@@ -869,61 +1016,67 @@ uint16_t Modbus::calcCRC(uint8_t u8length) {
  * @return 0 if OK, EXCEPTION if anything fails
  * @ingroup buffer
  */
-uint8_t Modbus::validateRequest() {
-  // check message crc vs calculated crc
-  uint16_t u16MsgCRC = 
-    ((au8Buffer[u8BufferSize - 2] << 8) 
-    | au8Buffer[u8BufferSize - 1]); // combine the crc Low & High bytes
-  if ( calcCRC( u8BufferSize-2 ) != u16MsgCRC ) {
-    u16errCnt ++;
-    return NO_REPLY;
-  }
-
-  // check fct code
-  boolean isSupported = false;
-  for (uint8_t i = 0; i< sizeof( fctsupported ); i++) {
-    if (fctsupported[i] == au8Buffer[FUNC]) {
-      isSupported = 1;
-      break;
+uint8_t Modbus::validateRequest()
+{
+    // check message crc vs calculated crc
+    uint16_t u16MsgCRC =
+        ((au8Buffer[u8BufferSize - 2] << 8)
+         | au8Buffer[u8BufferSize - 1]); // combine the crc Low & High bytes
+    if ( calcCRC( u8BufferSize-2 ) != u16MsgCRC )
+    {
+        u16errCnt ++;
+        return NO_REPLY;
     }
-  }
-  if (!isSupported) {
-    u16errCnt ++;
-    return EXC_FUNC_CODE;
-  }
 
-  // check start address & nb range
-  uint16_t u16regs = 0;
-  uint8_t u8regs;
-  switch ( au8Buffer[ FUNC ] ) {
-  case MB_FC_READ_COILS:
-  case MB_FC_READ_DISCRETE_INPUT:
-  case MB_FC_WRITE_MULTIPLE_COILS:
-    u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]) / 16;
-    u16regs += word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ]) /16;
-    u8regs = (uint8_t) u16regs;
-    if (u8regs > u8regsize) return EXC_ADDR_RANGE;
-    break;
-  case MB_FC_WRITE_COIL:
-    u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]) / 16;
-    u8regs = (uint8_t) u16regs;
-    if (u8regs > u8regsize) return EXC_ADDR_RANGE;
-    break;  
-  case MB_FC_WRITE_REGISTER :
-    u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]);
-    u8regs = (uint8_t) u16regs;
-    if (u8regs > u8regsize) return EXC_ADDR_RANGE;
-    break;
-  case MB_FC_READ_REGISTERS :
-  case MB_FC_READ_INPUT_REGISTER :
-  case MB_FC_WRITE_MULTIPLE_REGISTERS :
-    u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]);
-    u16regs += word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ]);
-    u8regs = (uint8_t) u16regs;
-    if (u8regs > u8regsize) return EXC_ADDR_RANGE;    
-    break;
-  }
-  return 0; // OK, no exception code thrown
+    // check fct code
+    boolean isSupported = false;
+    for (uint8_t i = 0; i< sizeof( fctsupported ); i++)
+    {
+        if (fctsupported[i] == au8Buffer[FUNC])
+        {
+            isSupported = 1;
+            break;
+        }
+    }
+    if (!isSupported)
+    {
+        u16errCnt ++;
+        return EXC_FUNC_CODE;
+    }
+
+    // check start address & nb range
+    uint16_t u16regs = 0;
+    uint8_t u8regs;
+    switch ( au8Buffer[ FUNC ] )
+    {
+    case MB_FC_READ_COILS:
+    case MB_FC_READ_DISCRETE_INPUT:
+    case MB_FC_WRITE_MULTIPLE_COILS:
+        u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]) / 16;
+        u16regs += word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ]) /16;
+        u8regs = (uint8_t) u16regs;
+        if (u8regs > u8regsize) return EXC_ADDR_RANGE;
+        break;
+    case MB_FC_WRITE_COIL:
+        u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]) / 16;
+        u8regs = (uint8_t) u16regs;
+        if (u8regs > u8regsize) return EXC_ADDR_RANGE;
+        break;
+    case MB_FC_WRITE_REGISTER :
+        u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]);
+        u8regs = (uint8_t) u16regs;
+        if (u8regs > u8regsize) return EXC_ADDR_RANGE;
+        break;
+    case MB_FC_READ_REGISTERS :
+    case MB_FC_READ_INPUT_REGISTER :
+    case MB_FC_WRITE_MULTIPLE_REGISTERS :
+        u16regs = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ]);
+        u16regs += word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ]);
+        u8regs = (uint8_t) u16regs;
+        if (u8regs > u8regsize) return EXC_ADDR_RANGE;
+        break;
+    }
+    return 0; // OK, no exception code thrown
 }
 
 /**
@@ -933,36 +1086,42 @@ uint8_t Modbus::validateRequest() {
  * @return 0 if OK, EXCEPTION if anything fails
  * @ingroup buffer
  */
-uint8_t Modbus::validateAnswer() {
-  // check message crc vs calculated crc
-  uint16_t u16MsgCRC = 
-    ((au8Buffer[u8BufferSize - 2] << 8) 
-    | au8Buffer[u8BufferSize - 1]); // combine the crc Low & High bytes
-  if ( calcCRC( u8BufferSize-2 ) != u16MsgCRC ) {
-    u16errCnt ++;
-    return NO_REPLY;
-  }
-
-  // check exception
-  if ((au8Buffer[ FUNC ] & 0x80) != 0) {
-    u16errCnt ++;
-    return ERR_EXCEPTION;
-  }
-
-  // check fct code
-  boolean isSupported = false;
-  for (uint8_t i = 0; i< sizeof( fctsupported ); i++) {
-    if (fctsupported[i] == au8Buffer[FUNC]) {
-      isSupported = 1;
-      break;
+uint8_t Modbus::validateAnswer()
+{
+    // check message crc vs calculated crc
+    uint16_t u16MsgCRC =
+        ((au8Buffer[u8BufferSize - 2] << 8)
+         | au8Buffer[u8BufferSize - 1]); // combine the crc Low & High bytes
+    if ( calcCRC( u8BufferSize-2 ) != u16MsgCRC )
+    {
+        u16errCnt ++;
+        return NO_REPLY;
     }
-  }
-  if (!isSupported) {
-    u16errCnt ++;
-    return EXC_FUNC_CODE;
-  }
 
-  return 0; // OK, no exception code thrown
+    // check exception
+    if ((au8Buffer[ FUNC ] & 0x80) != 0)
+    {
+        u16errCnt ++;
+        return ERR_EXCEPTION;
+    }
+
+    // check fct code
+    boolean isSupported = false;
+    for (uint8_t i = 0; i< sizeof( fctsupported ); i++)
+    {
+        if (fctsupported[i] == au8Buffer[FUNC])
+        {
+            isSupported = 1;
+            break;
+        }
+    }
+    if (!isSupported)
+    {
+        u16errCnt ++;
+        return EXC_FUNC_CODE;
+    }
+
+    return 0; // OK, no exception code thrown
 }
 
 /**
@@ -971,50 +1130,54 @@ uint8_t Modbus::validateAnswer() {
  *
  * @ingroup buffer
  */
-void Modbus::buildException( uint8_t u8exception ) {
-  uint8_t u8func = au8Buffer[ FUNC ];  // get the original FUNC code
+void Modbus::buildException( uint8_t u8exception )
+{
+    uint8_t u8func = au8Buffer[ FUNC ];  // get the original FUNC code
 
-  au8Buffer[ ID ]      = u8id;
-  au8Buffer[ FUNC ]    = u8func + 0x80;
-  au8Buffer[ 2 ]       = u8exception;
-  u8BufferSize         = EXCEPTION_SIZE;
+    au8Buffer[ ID ]      = u8id;
+    au8Buffer[ FUNC ]    = u8func + 0x80;
+    au8Buffer[ 2 ]       = u8exception;
+    u8BufferSize         = EXCEPTION_SIZE;
 }
 
 /**
  * This method processes functions 1 & 2 (for master)
- * This method puts the slave answer into master data buffer 
+ * This method puts the slave answer into master data buffer
  *
  * @ingroup register
  * TODO: finish its implementation
  */
-void Modbus::get_FC1() {
-  uint8_t u8byte, i;
-  u8byte = 0;
+void Modbus::get_FC1()
+{
+    uint8_t u8byte, i;
+    u8byte = 0;
 
-  //  for (i=0; i< au8Buffer[ 2 ] /2; i++) {
-  //    au16regs[ i ] = word( 
-  //    au8Buffer[ u8byte ],
-  //    au8Buffer[ u8byte +1 ]);
-  //    u8byte += 2;
-  //  }
+    //  for (i=0; i< au8Buffer[ 2 ] /2; i++) {
+    //    au16regs[ i ] = word(
+    //    au8Buffer[ u8byte ],
+    //    au8Buffer[ u8byte +1 ]);
+    //    u8byte += 2;
+    //  }
 }
 
 /**
  * This method processes functions 3 & 4 (for master)
- * This method puts the slave answer into master data buffer 
+ * This method puts the slave answer into master data buffer
  *
  * @ingroup register
  */
-void Modbus::get_FC3() {
-  uint8_t u8byte, i;
-  u8byte = 3;
+void Modbus::get_FC3()
+{
+    uint8_t u8byte, i;
+    u8byte = 3;
 
-  for (i=0; i< au8Buffer[ 2 ] /2; i++) {
-    au16regs[ i ] = word( 
-    au8Buffer[ u8byte ],
-    au8Buffer[ u8byte +1 ]);
-    u8byte += 2;
-  }
+    for (i=0; i< au8Buffer[ 2 ] /2; i++)
+    {
+        au16regs[ i ] = word(
+                            au8Buffer[ u8byte ],
+                            au8Buffer[ u8byte +1 ]);
+        u8byte += 2;
+    }
 }
 
 /**
@@ -1025,46 +1188,49 @@ void Modbus::get_FC3() {
  * @return u8BufferSize Response to master length
  * @ingroup discrete
  */
-int8_t Modbus::process_FC1( uint16_t *regs, uint8_t u8size ) {
-  uint8_t u8currentRegister, u8currentBit, u8bytesno, u8bitsno;
-  uint8_t u8CopyBufferSize;
-  uint16_t u16currentCoil, u16coil;
+int8_t Modbus::process_FC1( uint16_t *regs, uint8_t u8size )
+{
+    uint8_t u8currentRegister, u8currentBit, u8bytesno, u8bitsno;
+    uint8_t u8CopyBufferSize;
+    uint16_t u16currentCoil, u16coil;
 
-  // get the first and last coil from the message
-  uint16_t u16StartCoil = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
-  uint16_t u16Coilno = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
+    // get the first and last coil from the message
+    uint16_t u16StartCoil = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
+    uint16_t u16Coilno = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
 
-  // put the number of bytes in the outcoming message
-  u8bytesno = (uint8_t) (u16Coilno / 8);
-  if (u16Coilno % 8 != 0) u8bytesno ++;
-  au8Buffer[ ADD_HI ]  = u8bytesno;
-  u8BufferSize         = ADD_LO;
+    // put the number of bytes in the outcoming message
+    u8bytesno = (uint8_t) (u16Coilno / 8);
+    if (u16Coilno % 8 != 0) u8bytesno ++;
+    au8Buffer[ ADD_HI ]  = u8bytesno;
+    u8BufferSize         = ADD_LO;
 
-  // read each coil from the register map and put its value inside the outcoming message
-  u8bitsno = 0;
+    // read each coil from the register map and put its value inside the outcoming message
+    u8bitsno = 0;
 
-  for (u16currentCoil = 0; u16currentCoil < u16Coilno; u16currentCoil++) {
-    u16coil = u16StartCoil + u16currentCoil;
-    u8currentRegister = (uint8_t) (u16coil / 16);
-    u8currentBit = (uint8_t) (u16coil % 16);
+    for (u16currentCoil = 0; u16currentCoil < u16Coilno; u16currentCoil++)
+    {
+        u16coil = u16StartCoil + u16currentCoil;
+        u8currentRegister = (uint8_t) (u16coil / 16);
+        u8currentBit = (uint8_t) (u16coil % 16);
 
-    bitWrite(
-    au8Buffer[ u8BufferSize ],
-    u8bitsno,
-    bitRead( regs[ u8currentRegister ], u8currentBit ) );
-    u8bitsno ++;
+        bitWrite(
+            au8Buffer[ u8BufferSize ],
+            u8bitsno,
+            bitRead( regs[ u8currentRegister ], u8currentBit ) );
+        u8bitsno ++;
 
-    if (u8bitsno > 7) {
-      u8bitsno = 0;
-      u8BufferSize++;
+        if (u8bitsno > 7)
+        {
+            u8bitsno = 0;
+            u8BufferSize++;
+        }
     }
-  }
 
-  // send outcoming message
-  if (u16Coilno % 8 != 0) u8BufferSize ++;
-  u8CopyBufferSize = u8BufferSize +2;
-  sendTxBuffer();
-  return u8CopyBufferSize;
+    // send outcoming message
+    if (u16Coilno % 8 != 0) u8BufferSize ++;
+    u8CopyBufferSize = u8BufferSize +2;
+    sendTxBuffer();
+    return u8CopyBufferSize;
 }
 
 /**
@@ -1075,26 +1241,28 @@ int8_t Modbus::process_FC1( uint16_t *regs, uint8_t u8size ) {
  * @return u8BufferSize Response to master length
  * @ingroup register
  */
-int8_t Modbus::process_FC3( uint16_t *regs, uint8_t u8size ) {
+int8_t Modbus::process_FC3( uint16_t *regs, uint8_t u8size )
+{
 
-  uint8_t u8StartAdd = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
-  uint8_t u8regsno = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
-  uint8_t u8CopyBufferSize;
-  uint8_t i;
+    uint8_t u8StartAdd = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
+    uint8_t u8regsno = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
+    uint8_t u8CopyBufferSize;
+    uint8_t i;
 
-  au8Buffer[ 2 ]       = u8regsno * 2;
-  u8BufferSize         = 3;
+    au8Buffer[ 2 ]       = u8regsno * 2;
+    u8BufferSize         = 3;
 
-  for (i = u8StartAdd; i < u8StartAdd + u8regsno; i++) {
-    au8Buffer[ u8BufferSize ] = highByte(regs[i]);
-    u8BufferSize++;
-    au8Buffer[ u8BufferSize ] = lowByte(regs[i]);
-    u8BufferSize++;
-  }
-  u8CopyBufferSize = u8BufferSize +2;
-  sendTxBuffer();
+    for (i = u8StartAdd; i < u8StartAdd + u8regsno; i++)
+    {
+        au8Buffer[ u8BufferSize ] = highByte(regs[i]);
+        u8BufferSize++;
+        au8Buffer[ u8BufferSize ] = lowByte(regs[i]);
+        u8BufferSize++;
+    }
+    u8CopyBufferSize = u8BufferSize +2;
+    sendTxBuffer();
 
-  return u8CopyBufferSize;
+    return u8CopyBufferSize;
 }
 
 /**
@@ -1105,28 +1273,29 @@ int8_t Modbus::process_FC3( uint16_t *regs, uint8_t u8size ) {
  * @return u8BufferSize Response to master length
  * @ingroup discrete
  */
-int8_t Modbus::process_FC5( uint16_t *regs, uint8_t u8size ) {
-  uint8_t u8currentRegister, u8currentBit;
-  uint8_t u8CopyBufferSize;
-  uint16_t u16coil = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
+int8_t Modbus::process_FC5( uint16_t *regs, uint8_t u8size )
+{
+    uint8_t u8currentRegister, u8currentBit;
+    uint8_t u8CopyBufferSize;
+    uint16_t u16coil = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
 
-  // point to the register and its bit
-  u8currentRegister = (uint8_t) (u16coil / 16);
-  u8currentBit = (uint8_t) (u16coil % 16);
+    // point to the register and its bit
+    u8currentRegister = (uint8_t) (u16coil / 16);
+    u8currentBit = (uint8_t) (u16coil % 16);
 
-  // write to coil
-  bitWrite(
-  regs[ u8currentRegister ],
-  u8currentBit,
-  au8Buffer[ NB_HI ] == 0xff );
+    // write to coil
+    bitWrite(
+        regs[ u8currentRegister ],
+        u8currentBit,
+        au8Buffer[ NB_HI ] == 0xff );
 
 
-  // send answer to master
-  u8BufferSize = 6;
-  u8CopyBufferSize = u8BufferSize +2;
-  sendTxBuffer();
+    // send answer to master
+    u8BufferSize = 6;
+    u8CopyBufferSize = u8BufferSize +2;
+    sendTxBuffer();
 
-  return u8CopyBufferSize;
+    return u8CopyBufferSize;
 }
 
 /**
@@ -1137,21 +1306,22 @@ int8_t Modbus::process_FC5( uint16_t *regs, uint8_t u8size ) {
  * @return u8BufferSize Response to master length
  * @ingroup register
  */
-int8_t Modbus::process_FC6( uint16_t *regs, uint8_t u8size ) {
+int8_t Modbus::process_FC6( uint16_t *regs, uint8_t u8size )
+{
 
-  uint8_t u8add = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
-  uint8_t u8CopyBufferSize;
-  uint16_t u16val = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
+    uint8_t u8add = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
+    uint8_t u8CopyBufferSize;
+    uint16_t u16val = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
 
-  regs[ u8add ] = u16val;
+    regs[ u8add ] = u16val;
 
-  // keep the same header
-  u8BufferSize         = RESPONSE_SIZE;
+    // keep the same header
+    u8BufferSize         = RESPONSE_SIZE;
 
-  u8CopyBufferSize = u8BufferSize +2;
-  sendTxBuffer();
+    u8CopyBufferSize = u8BufferSize +2;
+    sendTxBuffer();
 
-  return u8CopyBufferSize;
+    return u8CopyBufferSize;
 }
 
 /**
@@ -1162,49 +1332,52 @@ int8_t Modbus::process_FC6( uint16_t *regs, uint8_t u8size ) {
  * @return u8BufferSize Response to master length
  * @ingroup discrete
  */
-int8_t Modbus::process_FC15( uint16_t *regs, uint8_t u8size ) {
-  uint8_t u8currentRegister, u8currentBit, u8frameByte, u8bitsno;
-  uint8_t u8CopyBufferSize;
-  uint16_t u16currentCoil, u16coil;
-  boolean bTemp;
+int8_t Modbus::process_FC15( uint16_t *regs, uint8_t u8size )
+{
+    uint8_t u8currentRegister, u8currentBit, u8frameByte, u8bitsno;
+    uint8_t u8CopyBufferSize;
+    uint16_t u16currentCoil, u16coil;
+    boolean bTemp;
 
-  // get the first and last coil from the message
-  uint16_t u16StartCoil = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
-  uint16_t u16Coilno = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
+    // get the first and last coil from the message
+    uint16_t u16StartCoil = word( au8Buffer[ ADD_HI ], au8Buffer[ ADD_LO ] );
+    uint16_t u16Coilno = word( au8Buffer[ NB_HI ], au8Buffer[ NB_LO ] );
 
 
-  // read each coil from the register map and put its value inside the outcoming message
-  u8bitsno = 0;
-  u8frameByte = 7;
-  for (u16currentCoil = 0; u16currentCoil < u16Coilno; u16currentCoil++) {
+    // read each coil from the register map and put its value inside the outcoming message
+    u8bitsno = 0;
+    u8frameByte = 7;
+    for (u16currentCoil = 0; u16currentCoil < u16Coilno; u16currentCoil++)
+    {
 
-    u16coil = u16StartCoil + u16currentCoil;
-    u8currentRegister = (uint8_t) (u16coil / 16);
-    u8currentBit = (uint8_t) (u16coil % 16);
+        u16coil = u16StartCoil + u16currentCoil;
+        u8currentRegister = (uint8_t) (u16coil / 16);
+        u8currentBit = (uint8_t) (u16coil % 16);
 
-    bTemp = bitRead(
-    au8Buffer[ u8frameByte ],
-    u8bitsno );
+        bTemp = bitRead(
+                    au8Buffer[ u8frameByte ],
+                    u8bitsno );
 
-    bitWrite(
-    regs[ u8currentRegister ],
-    u8currentBit,
-    bTemp );
+        bitWrite(
+            regs[ u8currentRegister ],
+            u8currentBit,
+            bTemp );
 
-    u8bitsno ++;
+        u8bitsno ++;
 
-    if (u8bitsno > 7) {
-      u8bitsno = 0;
-      u8frameByte++;
+        if (u8bitsno > 7)
+        {
+            u8bitsno = 0;
+            u8frameByte++;
+        }
     }
-  }
 
-  // send outcoming message
-  // it's just a copy of the incomping frame until 6th byte
-  u8BufferSize         = 6;
-  u8CopyBufferSize = u8BufferSize +2;
-  sendTxBuffer();
-  return u8CopyBufferSize;
+    // send outcoming message
+    // it's just a copy of the incomping frame until 6th byte
+    u8BufferSize         = 6;
+    u8CopyBufferSize = u8BufferSize +2;
+    sendTxBuffer();
+    return u8CopyBufferSize;
 }
 
 /**
@@ -1215,29 +1388,31 @@ int8_t Modbus::process_FC15( uint16_t *regs, uint8_t u8size ) {
  * @return u8BufferSize Response to master length
  * @ingroup register
  */
-int8_t Modbus::process_FC16( uint16_t *regs, uint8_t u8size ) {
-  uint8_t u8func = au8Buffer[ FUNC ];  // get the original FUNC code
-  uint8_t u8StartAdd = au8Buffer[ ADD_HI ] << 8 | au8Buffer[ ADD_LO ];
-  uint8_t u8regsno = au8Buffer[ NB_HI ] << 8 | au8Buffer[ NB_LO ];
-  uint8_t u8CopyBufferSize;
-  uint8_t i;
-  uint16_t temp;
+int8_t Modbus::process_FC16( uint16_t *regs, uint8_t u8size )
+{
+    uint8_t u8func = au8Buffer[ FUNC ];  // get the original FUNC code
+    uint8_t u8StartAdd = au8Buffer[ ADD_HI ] << 8 | au8Buffer[ ADD_LO ];
+    uint8_t u8regsno = au8Buffer[ NB_HI ] << 8 | au8Buffer[ NB_LO ];
+    uint8_t u8CopyBufferSize;
+    uint8_t i;
+    uint16_t temp;
 
-  // build header
-  au8Buffer[ NB_HI ]   = 0;
-  au8Buffer[ NB_LO ]   = u8regsno;
-  u8BufferSize         = RESPONSE_SIZE;
+    // build header
+    au8Buffer[ NB_HI ]   = 0;
+    au8Buffer[ NB_LO ]   = u8regsno;
+    u8BufferSize         = RESPONSE_SIZE;
 
-  // write registers
-  for (i = 0; i < u8regsno; i++) {
-    temp = word(
-    au8Buffer[ (BYTE_CNT + 1) + i * 2 ],
-    au8Buffer[ (BYTE_CNT + 2) + i * 2 ]);
+    // write registers
+    for (i = 0; i < u8regsno; i++)
+    {
+        temp = word(
+                   au8Buffer[ (BYTE_CNT + 1) + i * 2 ],
+                   au8Buffer[ (BYTE_CNT + 2) + i * 2 ]);
 
-    regs[ u8StartAdd + i ] = temp;
-  }
-  u8CopyBufferSize = u8BufferSize +2;
-  sendTxBuffer();
+        regs[ u8StartAdd + i ] = temp;
+    }
+    u8CopyBufferSize = u8BufferSize +2;
+    sendTxBuffer();
 
-  return u8CopyBufferSize;
+    return u8CopyBufferSize;
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ libmodbus is a library that provides a Serial Modbus implementation for Arduino.
 
 A primary goal was to enable industrial communication for the Arduino in order to link it to industrial devices such as HMIs, CNCs, PLCs, temperature regulators or speed drives.
 
+now you can use software serial with the update from Helium6072!
+
 LIBRARY CONTENTS
 =================================================================
 LICENSE.txt			GNU Licence file
@@ -19,6 +21,7 @@ Sample sketches to implement miscellaneous settings:
 /examples/RS485_slave		Modbus slave adapted to the RS485 port
 /examples/simple_master		Modbus master node with a single query
 /examples/simple_slave		Modbus slave node with a link array
+/examples/software_serial_simple_master		Modbus master node that works via software serial
 
 INSTALLATION PROCEDURE
 =================================================================
@@ -65,3 +68,13 @@ Master:
 
 3) Other codes under development
 
+New features by Helium6072 29 July 2016
+=================================================================
+1) "port->flush();" changed into "while(port->read() >= 0);"
+
+Since Serial.flush() (port->flush(); in ModbusRtu.h line 287, 337, & 827) no longer empties incoming buffer on 1.6 (Arduino.cc : flush() "Waits for the transmission of outgoing serial data to complete. Prior to Arduino 1.0, this instead removed any buffered incoming serial data.), use "while(port->read() >= 0);" instead.
+
+2) software serial compatible
+
+New constructor Modbus::Modbus(uint8_t u8id) and method void Modbus::begin(SoftwareSerial *sPort, long u32speed) that makes using software serial possible.
+Check out sexample "software_serial_simple_master" and learn more!

--- a/examples/software_serial_simple_master/software_serial_simple_master.ino
+++ b/examples/software_serial_simple_master/software_serial_simple_master.ino
@@ -1,0 +1,101 @@
+/**
+ *  Modbus master example 2:
+ *  The purpose of this example is to query an array of data
+ *  from an external Modbus slave device.
+ *  This example is similar to "simple_master", but this example
+ *  allows you to use software serial instead of hardware serial
+ *  in case that you want to use D1 & D2 for other purposes.
+ *  The link media can be USB or RS232.
+ 
+  The circuit:
+ * software serial rx(D3) connect to tx pin of another device
+ * software serial tx(D4) connect to rx pin of another device
+ 
+ * In this example, we will use two important methods so that we can use
+ * software serial.
+ *
+ * 1. Modbus::Modbus(uint8_t u8id)
+ * This is a constructor for a Master/Slave through USB/RS232C via software serial
+ * This constructor only specifies u8id (node address) and should be only
+ * used if you want to use software serial instead of hardware serial.
+ * This method is called if you create a ModBus object with only on parameter "u8id"
+ * u8id is the node address of the arduino that will be programmed on,
+ * 0 for master and 1..247 for slave
+ * for example: Modbus master(0); 
+ * If you use this constructor you have to begin ModBus object by
+ * using "void Modbus::begin(SoftwareSerial *softPort, long u32speed)".
+ * 
+ * 2. void Modbus::begin(SoftwareSerial *sPort, long u32speed)
+ * Initialize class object.
+ * This is the method you have to use if you construct the ModBus object by using 
+ * Modbus::Modbus(uint8_t u8id) in order to use software serial and to avoid problems.
+ * You have to create a SoftwareSerial object on your own, as shown in the example.
+ * sPort is a pointer to your SoftwareSerial object, u32speed is the baud rate, in 
+ * standard increments (300..115200)
+
+ created long time ago
+ by smarmengol
+ modified 29 July 2016
+ by Helium6072
+
+ This example code is in the public domain.
+ */
+
+#include <ModbusRtu.h>
+#include <SoftwareSerial.h>
+
+// data array for modbus network sharing
+uint16_t au16data[16];
+uint8_t u8state;
+
+/**
+ *  Modbus object declaration
+ *  u8id : node id = 0 for master, = 1..247 for slave
+ *  u8serno : serial port (use 0 for Serial)
+ *  u8txenpin : 0 for RS-232 and USB-FTDI 
+ *               or any pin number > 1 for RS-485
+ */
+Modbus master(0); // this is master and RS-232 or USB-FTDI via software serial
+
+/**
+ * This is an structe which contains a query to an slave device
+ */
+modbus_t telegram;
+
+unsigned long u32wait;
+
+SoftwareSerial mySerial(3, 5);//Create a SoftwareSerial object so that we can use software serial. Search "software serial" on Arduino.cc to find out more details.
+
+void setup() {
+  Serial.begin(9600);//use the hardware serial if you want to connect to your computer via usb cable, etc.
+  master.begin( &mySerial, 9600 ); // begin the ModBus object. The first parameter is the address of your SoftwareSerial address. Do not forget the "&". 9600 means baud-rate at 9600
+  master.setTimeOut( 2000 ); // if there is no answer in 2000 ms, roll over
+  u32wait = millis() + 1000;
+  u8state = 0; 
+}
+
+void loop() {
+  switch( u8state ) {
+  case 0: 
+    if (millis() > u32wait) u8state++; // wait state
+    break;
+  case 1: 
+    telegram.u8id = 104; // slave address
+    telegram.u8fct = 4; // function code (this one is registers read)
+    telegram.u16RegAdd = 3; // start address in slave
+    telegram.u16CoilsNo = 1; // number of elements (coils or registers) to read
+    telegram.au16reg = au16data; // pointer to a memory array in the Arduino
+
+    master.query( telegram ); // send query (only once)
+    u8state++;
+    break;
+  case 2:
+    master.poll(); // check incoming messages
+    if (master.getState() == COM_IDLE) {
+      u8state = 0;
+      u32wait = millis() + 2000; 
+        Serial.println(au16data[0]);//Or do something else!
+    }
+    break;
+  }
+}


### PR DESCRIPTION
I'm sorry that I auto-formatted ModbusRtu.h and as a result the differences between two versions cannot be spotted easily... I didn't mean to...
So the changes are listed as followed.

1) "port->flush();" changed into "while(port->read() >= 0);"

Since Serial.flush() (port->flush(); in ModbusRtu.h line 287, 337, & 827) no longer empties incoming buffer on 1.6 (Arduino.cc : flush() "Waits for the transmission of outgoing serial data to complete. Prior to Arduino 1.0, this instead removed any buffered incoming serial data.), use "while(port->read() >= 0);" instead.

2) software serial compatible

New constructor Modbus::Modbus(uint8_t u8id) and method void Modbus::begin(SoftwareSerial *sPort, long u32speed) that makes using software serial possible.
Also a new method void init(uint8_t u8id); and a few changes that makes old methods compatible with software serial.