### PR TITLE
ModbusRtu.h: Set getLastError() to 0 on new query

### DIFF
--- a/ModbusRtu.h
+++ b/ModbusRtu.h
@@ -636,6 +636,7 @@ int8_t Modbus::query( modbus_t telegram )
 
     sendTxBuffer();
     u8state = COM_WAITING;
+    u8lastError = 0;
     return 0;
 }
 


### PR DESCRIPTION
Set getLastError() to 0 on new query.
